### PR TITLE
Add Support for Decrypting Audio and Document Messages in WhatsApp Media Decrypt Node

### DIFF
--- a/whatsapp-media-decrypt.html
+++ b/whatsapp-media-decrypt.html
@@ -24,26 +24,25 @@
 
 
 <script type="text/html" data-help-name="decrypt-media">
-  <p>Connect to Azure OpenAI ChatGPT service</p>
+  <p>Decrypts WhatsApp media messages (image, audio, document).</p>
 
   <h3>Inputs</h3>
   <dl class="message-properties">
-    <dt>msg.message.imageMessage.url <span class="property-type">string</span></dt>
-    <dd> url of the whatsapp media</dd>
-    <dt>msg.message.imageMessage.mimetype <span class="property-type">string</span></dt>
-    <dd> mimetype of the media, e.g. 'image/jpeg'</dd>
-    <dt>msg.message.imageMessage.fileLength <span class="property-type">string</span></dt>
-    <dd> the length of the decrypted file</dd>
-    <dt>.msg.essage.imageMessage.fileEncSha256 <span class="property-type">string</span></dt>
-    <dd> sha256 hash of the encrypted file</dd>
-    <dt>msg.message.imageMessage.mediaKey <span class="property-type">string</span></dt>
-    <dd> decryption key of the media</dd>
+    <dt>msg.message.imageMessage <span class="property-type">object</span></dt>
+    <dd>Contains properties of the image message.</dd>
+    <dt>msg.message.audioMessage <span class="property-type">object</span></dt>
+    <dd>Contains properties of the audio message.</dd>
+    <dt>msg.message.documentMessage <span class="property-type">object</span></dt>
+    <dd>Contains properties of the document message.</dd>
   </dl>
 
   <h3>Outputs</h3>
   <dl class="message-properties">
     <dt>msg.imageMessageBuffer <span class="property-type">Buffer</span></dt>
-    <dd> image response as buffer</dd>
+    <dd>Decrypted image data as a Buffer.</dd>
+    <dt>msg.audioMessageBuffer <span class="property-type">Buffer</span></dt>
+    <dd>Decrypted audio data as a Buffer.</dd>
+    <dt>msg.documentMessageBuffer <span class="property-type">Buffer</span></dt>
+    <dd>Decrypted document data as a Buffer.</dd>
   </dl>
-
 </script>

--- a/whatsapp-media-decrypt.html
+++ b/whatsapp-media-decrypt.html
@@ -1,4 +1,4 @@
-<!-- node -->
+<!-- Node Definition -->
 <script type="text/javascript">
   RED.nodes.registerType('decrypt-media', {
     category: 'whatsapp',
@@ -15,6 +15,7 @@
   });
 </script>
 
+<!-- Node HTML -->
 <script type="text/html" data-template-name="decrypt-media">
   <div class="form-row">
     <label for="node-input-name"><i class="icon-tag"></i> Name</label>
@@ -22,7 +23,7 @@
   </div>
 </script>
 
-
+<!-- Node Help -->
 <script type="text/html" data-help-name="decrypt-media">
   <p>Decrypts WhatsApp media messages (image, audio, document).</p>
 

--- a/whatsapp-media-decrypt.js
+++ b/whatsapp-media-decrypt.js
@@ -12,13 +12,16 @@ module.exports = function (RED) {
         let response;
         try {
           if (msg.message.imageMessage) {
-            response = await getWhatsappMedia(msg.message.imageMessage, "WhatsApp Image Keys");
+            const { url, fileEncSha256, mediaKey, fileLength } = msg.message.imageMessage;
+            response = await getWhatsappMedia({ url, fileEncSha256, mediaKey, fileLength }, "WhatsApp Image Keys");
             msg.imageMessageBuffer = response;
           } else if (msg.message.audioMessage) {
-            response = await getWhatsappMedia(msg.message.audioMessage, "WhatsApp Audio Keys");
+            const { url, fileEncSha256, mediaKey, fileLength } = msg.message.audioMessage;
+            response = await getWhatsappMedia({ url, fileEncSha256, mediaKey, fileLength }, "WhatsApp Audio Keys");
             msg.audioMessageBuffer = response;
           } else if (msg.message.documentMessage) {
-            response = await getWhatsappMedia(msg.message.documentMessage, "WhatsApp Document Keys");
+            const { url, fileEncSha256, mediaKey, fileLength } = msg.message.documentMessage;
+            response = await getWhatsappMedia({ url, fileEncSha256, mediaKey, fileLength }, "WhatsApp Document Keys");
             msg.documentMessageBuffer = response;
           } else {
             node.send(msg);
@@ -28,6 +31,7 @@ module.exports = function (RED) {
 
         } catch (err) {
           console.error("Encountered an error:", err);
+          node.error(err.message, msg);
           return;
         }
       } else {

--- a/whatsapp-media-decrypt.js
+++ b/whatsapp-media-decrypt.js
@@ -7,26 +7,36 @@ module.exports = function (RED) {
     this.name = config.name;
 
     node.on('input', async function (msg) {
-      if (!(msg.message && msg.message.imageMessage)) {
-        node.send(msg);
-        return;
-      }
+      if (msg.message) {
+        const { getWhatsappMedia } = await import('./src/decryptWhatsappMedia.mjs');
+        let response;
+        try {
+          if (msg.message.imageMessage) {
+            response = await getWhatsappMedia(msg.message.imageMessage, "WhatsApp Image Keys");
+            msg.imageMessageBuffer = response;
+          } else if (msg.message.audioMessage) {
+            response = await getWhatsappMedia(msg.message.audioMessage, "WhatsApp Audio Keys");
+            msg.audioMessageBuffer = response;
+          } else if (msg.message.documentMessage) {
+            response = await getWhatsappMedia(msg.message.documentMessage, "WhatsApp Document Keys");
+            msg.documentMessageBuffer = response;
+          } else {
+            node.send(msg);
+            return;
+          }
+          node.send(msg);
 
-      const { getWhatsappImageMedia } = await import('./src/decryptWhatsappMedia.mjs');
-      try {
-        const response = await getWhatsappImageMedia(msg.message.imageMessage);
-        msg.imageMessageBuffer = response;
+        } catch (err) {
+          console.error("Encountered an error:", err);
+          return;
+        }
+      } else {
         node.send(msg);
-
-      } catch (err) {
-        console.error("encountered an error:", err);
         return;
       }
     });
 
-
-    node.on('close', function () {
-    });
+    node.on('close', function () {});
   }
 
   RED.nodes.registerType("decrypt-media", DecryptWAMedia);


### PR DESCRIPTION
This pull request extends the functionality of the WhatsApp Media Decrypt node to support decrypting audio and document messages, in addition to images. The enhancement allows users to decrypt various media types received via WhatsApp, making the node more versatile and useful in different scenarios.
